### PR TITLE
feat: Add time-locked savings contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 settings/Mainnet.toml
 settings/Testnet.toml
 history.txt
+activate.sh

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -1,20 +1,22 @@
-
 [project]
 name = "time-locked-savings"
 authors = []
+description = ""
 telemetry = false
+requirements = []
+[contracts.savings-account]
+path = "contracts/savings-account.clar"
+depends_on = []
+
+[repl]
+costs_version = 2
+parser_version = 2
+
 [repl.analysis]
 passes = ["check_checker"]
-[repl.analysis.check_checker]
-# If true, inputs are trusted after tx_sender has been checked.
-trusted_sender = false
-# If true, inputs are trusted after contract-caller has been checked.
-trusted_caller = false
-# If true, untrusted data may be passed into a private function without a
-# warning, if it gets checked inside. This check will also propagate up to the
-# caller.
-callee_filter = false
 
-# [contracts.counter]
-# path = "contracts/counter.clar"
-# depends_on = []
+[repl.analysis.check_checker]
+strict = false
+trusted_sender = false
+trusted_caller = false
+callee_filter = false

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Time-Locked Savings Account
+
+A blockchain-based savings account that implements time-locked deposits with early withdrawal penalties. 
+
+## Features
+- Deposit STX tokens with a custom lock duration
+- Early withdrawals possible with 10% penalty
+- Penalty-free withdrawals after lock period expires
+- Full transparency of savings data on-chain
+
+## Use Cases
+- Forced savings mechanism
+- Long-term token holding incentives
+- Staking with withdrawal restrictions

--- a/contracts/savings-account.clar
+++ b/contracts/savings-account.clar
@@ -1,0 +1,82 @@
+;; Time-locked savings account contract
+
+;; Constants
+(define-constant CONTRACT_OWNER tx-sender)
+(define-constant ERR_OWNER_ONLY (err u100))
+(define-constant ERR_INVALID_AMOUNT (err u101))
+(define-constant ERR_NO_SAVINGS (err u102))
+(define-constant ERR_LOCK_NOT_EXPIRED (err u103))
+(define-constant PENALTY_RATE u10) ;; 10% penalty for early withdrawal
+
+;; Data vars
+(define-map savings
+    principal
+    {
+        amount: uint,
+        lock-until: uint,
+        start-height: uint
+    }
+)
+
+;; Private functions
+(define-private (calculate-penalty (amount uint))
+    (/ (* amount PENALTY_RATE) u100)
+)
+
+;; Public functions
+(define-public (deposit (lock-duration uint))
+    (let 
+        (
+            (amount (stx-get-balance tx-sender))
+            (current-height block-height)
+            (lock-until (+ block-height lock-duration))
+        )
+        (asserts! (> amount u0) ERR_INVALID_AMOUNT)
+        (try! (stx-transfer? amount tx-sender (as-contract tx-sender)))
+        (map-set savings tx-sender {
+            amount: amount,
+            lock-until: lock-until,
+            start-height: current-height
+        })
+        (ok true)
+    )
+)
+
+(define-public (withdraw)
+    (let 
+        (
+            (savings-data (unwrap! (map-get? savings tx-sender) ERR_NO_SAVINGS))
+            (current-height block-height)
+            (amount (get amount savings-data))
+            (lock-until (get lock-until savings-data))
+        )
+        (if (>= current-height lock-until)
+            ;; Normal withdrawal - no penalty
+            (begin
+                (map-delete savings tx-sender)
+                (as-contract (stx-transfer? amount (as-contract tx-sender) tx-sender))
+                (ok true)
+            )
+            ;; Early withdrawal - apply penalty
+            (let
+                (
+                    (penalty (calculate-penalty amount))
+                    (withdrawal-amount (- amount penalty))
+                )
+                (map-delete savings tx-sender)
+                (as-contract (stx-transfer? withdrawal-amount (as-contract tx-sender) tx-sender))
+                (as-contract (stx-transfer? penalty (as-contract tx-sender) CONTRACT_OWNER))
+                (ok true)
+            )
+        )
+    )
+)
+
+;; Read only functions
+(define-read-only (get-savings (account principal))
+    (map-get? savings account)
+)
+
+(define-read-only (get-penalty-rate)
+    PENALTY_RATE
+)

--- a/tests/savings-account_test.ts
+++ b/tests/savings-account_test.ts
@@ -1,0 +1,80 @@
+import {
+    Clarinet,
+    Tx,
+    Chain,
+    Account,
+    types
+} from 'https://deno.land/x/clarinet@v1.0.0/index.ts';
+import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
+
+Clarinet.test({
+    name: "Can deposit STX and create savings account",
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        const wallet1 = accounts.get('wallet_1')!;
+        
+        let block = chain.mineBlock([
+            Tx.contractCall('savings-account', 'deposit', [
+                types.uint(100)  // Lock duration of 100 blocks
+            ], wallet1.address)
+        ]);
+        
+        block.receipts[0].result.expectOk().expectBool(true);
+        
+        // Check savings data
+        let getBalance = chain.callReadOnlyFn(
+            'savings-account',
+            'get-savings',
+            [types.principal(wallet1.address)],
+            wallet1.address
+        );
+        
+        assertEquals(getBalance.result.expectSome().expectTuple()['lock-until'], types.uint(block.height + 100));
+    }
+});
+
+Clarinet.test({
+    name: "Cannot withdraw before lock period ends, but can with penalty",
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        const wallet1 = accounts.get('wallet_1')!;
+        
+        // First deposit
+        let block = chain.mineBlock([
+            Tx.contractCall('savings-account', 'deposit', [
+                types.uint(100)
+            ], wallet1.address)
+        ]);
+        
+        // Try to withdraw early
+        let withdrawBlock = chain.mineBlock([
+            Tx.contractCall('savings-account', 'withdraw', [], wallet1.address)
+        ]);
+        
+        withdrawBlock.receipts[0].result.expectOk().expectBool(true);
+        // Check that penalty was applied
+    }
+});
+
+Clarinet.test({
+    name: "Can withdraw full amount after lock period",
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        const wallet1 = accounts.get('wallet_1')!;
+        
+        // Deposit
+        let block = chain.mineBlock([
+            Tx.contractCall('savings-account', 'deposit', [
+                types.uint(10)
+            ], wallet1.address)
+        ]);
+        
+        // Mine blocks until lock period ends
+        chain.mineEmptyBlockUntil(block.height + 11);
+        
+        // Withdraw
+        let withdrawBlock = chain.mineBlock([
+            Tx.contractCall('savings-account', 'withdraw', [], wallet1.address)
+        ]);
+        
+        withdrawBlock.receipts[0].result.expectOk().expectBool(true);
+        // Verify full amount received
+    }
+});


### PR DESCRIPTION
This PR implements a time-locked savings account with the following features:

- Users can deposit STX and specify a lock duration
- Early withdrawals incur a 10% penalty fee
- Full withdrawals available after lock period expires
- Penalties are sent to contract owner
- All savings data stored on-chain

The contract provides a mechanism for forced savings while allowing emergency withdrawals with penalties.